### PR TITLE
Enhance bulletin fetching and processing functionality

### DIFF
--- a/functions/src/cloudFunctions/fetchBulletin.ts
+++ b/functions/src/cloudFunctions/fetchBulletin.ts
@@ -1,18 +1,117 @@
 import {onSchedule} from "firebase-functions/v2/scheduler";
+import {onRequest} from "firebase-functions/v2/https";
 import * as admin from "firebase-admin";
 import {defineSecret} from "firebase-functions/params";
 
 const footballApiKey = defineSecret("FOOTBALL_API_KEY");
+const BASE_URL = "https://api.football-data.org/v4";
 
 interface ApiMatch {
   id: number;
   status: string;
-  [key: string]: any;
+  competition: {
+    id: number;
+    name: string;
+  };
+  homeTeam: {
+    id: number;
+    name: string;
+  };
+  awayTeam: {
+    id: number;
+    name: string;
+  };
+  score?: {
+    fullTime: {
+      home: number | null;
+      away: number | null;
+    };
+  };
 }
 
 /**
- * Fetches matches for today and next 2 days from the football API and saves them to Firestore
- * After saving, triggers processMatchDetails to fetch match details
+ * Helper function to fetch and save bulletin data
+ * Fetches matches, standings and triggers match details processing
+ * @param {string} dateFrom - The date to fetch bulletin for (YYYY-MM-DD)
+ */
+async function fetchAndSaveBulletin(dateFrom: string) {
+  console.log("\n🔄 Daily Bulletin Fetch Started");
+
+  // Get next 2 days
+  const dateTo = new Date(dateFrom);
+  dateTo.setDate(dateTo.getDate() + 2);
+  const dateToStr = dateTo.toISOString().split("T")[0];
+
+  console.log(`📅 Fetching matches from ${dateFrom} to ${dateToStr}`);
+
+  const response = await fetch(
+    `https://api.football-data.org/v4/matches?dateFrom=${dateFrom}&dateTo=${dateToStr}`,
+    {
+      headers: {
+        "X-Auth-Token": footballApiKey.value(),
+      },
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`API request failed with status ${response.status}`);
+  }
+
+  const data = await response.json();
+  const matches: ApiMatch[] = data.matches;
+
+  // Get unique competition IDs
+  const competitionIds = [...new Set(matches.map((match) => match.competition.id))];
+
+  const bulletinRef = admin.firestore().collection("dailyBulletins").doc(dateFrom);
+  await bulletinRef.set({
+    matches,
+    allDetailsProcessed: false,
+    lastProcessedIndex: 0,
+    standings: {},
+  });
+
+  console.log("📥 Bulletin saved to Firestore");
+
+  // Fetch standings for each competition
+  for (const competitionId of competitionIds) {
+    try {
+      const standingsResponse = await fetch(
+        `${BASE_URL}/competitions/${competitionId}/standings`,
+        {headers: {"X-Auth-Token": footballApiKey.value()}}
+      );
+
+      if (standingsResponse.ok) {
+        const standingsData = await standingsResponse.json();
+        await bulletinRef.collection("standings").doc(competitionId.toString()).set(standingsData);
+        console.log(`📊 Standings saved for competition ${competitionId}`);
+
+        // Rate limiting delay
+        await new Promise((resolve) => setTimeout(resolve, 6000)); // 6 seconds delay
+      }
+    } catch (error) {
+      console.error(`❌ Error fetching standings for competition ${competitionId}:`, error);
+    }
+  }
+
+  // Wait for 30 seconds before triggering match details to respect API rate limits
+  console.log("⏳ Waiting 50 seconds before triggering match details...");
+  await new Promise((resolve) => setTimeout(resolve, 50000));
+
+  // Trigger processMatchDetails function with a unique document
+  const triggerId = `${dateFrom}_${Date.now()}`;
+  await admin.firestore().collection("triggers").doc(triggerId).set({
+    type: "processMatchDetails",
+    date: dateFrom,
+    timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    status: "pending",
+  });
+
+  console.log("🔄 Triggered processMatchDetails function");
+}
+
+/**
+ * Scheduled function that runs daily at 04:00 to fetch new bulletin
  */
 export const fetchDailyBulletin = onSchedule({
   schedule: "0 4 * * *", // Her gün saat 04:00'te
@@ -21,59 +120,35 @@ export const fetchDailyBulletin = onSchedule({
   secrets: [footballApiKey],
   maxInstances: 1,
   minInstances: 0,
-  timeoutSeconds: 120, // 2 dakika yeterli olmalı
+  timeoutSeconds: 120,
   memory: "256MiB",
   concurrency: 1,
-}, async (context) => {
+}, async () => {
   try {
-    console.log("\n🔄 Daily Bulletin Fetch Started");
-
     const today = new Date();
     const dateFrom = today.toISOString().split("T")[0];
-
-    // Get next 2 days
-    const dateTo = new Date(today);
-    dateTo.setDate(dateTo.getDate() + 2);
-    const dateToStr = dateTo.toISOString().split("T")[0];
-
-    console.log(`📅 Fetching matches from ${dateFrom} to ${dateToStr}`);
-
-    const response = await fetch(
-      `https://api.football-data.org/v4/matches?dateFrom=${dateFrom}&dateTo=${dateToStr}`,
-      {
-        headers: {
-          "X-Auth-Token": footballApiKey.value(),
-        },
-      }
-    );
-
-    if (!response.ok) {
-      throw new Error(`API request failed with status ${response.status}`);
-    }
-
-    const data = await response.json();
-    const matches: ApiMatch[] = data.matches;
-
-    const bulletinRef = admin.firestore().collection("dailyBulletins").doc(dateFrom);
-    await bulletinRef.set({
-      matches,
-      allDetailsProcessed: false,
-      lastProcessedIndex: 0,
-    });
-
-    console.log("📥 Bulletin saved to Firestore");
-
-    // Trigger processMatchDetails function with a unique document
-    const triggerId = `${dateFrom}_${Date.now()}`;
-    await admin.firestore().collection("triggers").doc(triggerId).set({
-      type: "processMatchDetails",
-      date: dateFrom,
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
-      status: "pending",
-    });
-
-    console.log("🔄 Triggered processMatchDetails function");
+    await fetchAndSaveBulletin(dateFrom);
   } catch (error) {
     console.error(`❌ Error in fetchDailyBulletin: ${error instanceof Error ? error.message : "Unknown error"}`);
+  }
+});
+
+/**
+ * HTTP endpoint for manual testing of bulletin fetching
+ * Can be triggered with a specific date parameter
+ */
+export const manualFetchBulletin = onRequest({
+  region: "europe-west1",
+  secrets: [footballApiKey],
+}, async (req, res) => {
+  try {
+    const date = req.query.date as string || new Date().toISOString().split("T")[0];
+    await fetchAndSaveBulletin(date);
+    res.json({success: true, message: "Bulletin fetched successfully"});
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
   }
 });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,5 +1,5 @@
 import * as admin from "firebase-admin";
 admin.initializeApp();
 
-export {fetchDailyBulletin} from "./cloudFunctions/fetchBulletin";
+export {fetchDailyBulletin, manualFetchBulletin} from "./cloudFunctions/fetchBulletin";
 export {processMatchDetailsV2} from "./cloudFunctions/processMatchDetails";


### PR DESCRIPTION
- Added manualFetchBulletin HTTP endpoint for on-demand bulletin fetching.
- Refactored fetchDailyBulletin to utilize a new helper function, fetchAndSaveBulletin, improving code organization.
- Expanded fetchAndSaveBulletin to fetch matches and standings, saving them to Firestore with improved error handling and logging.
- Updated processMatchDetailsV2 to handle batch processing of match details, including rate limiting and trigger creation for remaining matches.
- Enhanced getLeagueStandings to first check Firebase for cached standings before making API calls, improving efficiency.